### PR TITLE
Refactor entities to use UUIDs and switch to PostgreSQL

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,5 @@
-# .env
 DB_HOST=localhost
-DB_PORT=27017
+DB_PORT=5432
+DB_USERNAME=
+DB_PASSWORD=
 DB_NAME=mart-commerce

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@nestjs/core": "^11.0.1",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/typeorm": "^11.0.0",
-        "mongodb": "^6.16.0",
+        "pg": "^8.15.6",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1"
       },
@@ -1914,6 +1914,8 @@
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.2.2.tgz",
       "integrity": "sha512-EB0O3SCSNRUFk66iRCpI+cXzIjdswfCs7F6nOC3RAGJ7xr5YhaicvsRwJ9eyzYvYRlCSDUO/c7g4yNulxKC1WA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -3506,13 +3508,17 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
       "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/whatwg-url": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
       "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/webidl-conversions": "*"
       }
@@ -5179,6 +5185,8 @@
       "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.3.tgz",
       "integrity": "sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ==",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=16.20.1"
       }
@@ -8765,7 +8773,9 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
@@ -8938,6 +8948,8 @@
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.16.0.tgz",
       "integrity": "sha512-D1PNcdT0y4Grhou5Zi/qgipZOYeWrhLEpk33n3nm6LGtz61jvO88WlrWCK/bigMjpnOdAUKKQwsGIl0NtWMyYw==",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.9",
         "bson": "^6.10.3",
@@ -8984,6 +8996,8 @@
       "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
       "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/whatwg-url": "^11.0.2",
         "whatwg-url": "^14.1.0 || ^13.0.0"
@@ -9490,6 +9504,95 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.15.6",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.15.6.tgz",
+      "integrity": "sha512-yvao7YI3GdmmrslNVsZgx9PfntfWrnXwtR+K/DjI0I/sTKif4Z623um+sjVZ1hk5670B+ODjvHDAckKdjmPTsg==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.8.5",
+        "pg-pool": "^3.9.6",
+        "pg-protocol": "^1.9.5",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.5"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.5.tgz",
+      "integrity": "sha512-OOX22Vt0vOSRrdoUPKJ8Wi2OpE/o/h9T8X1s4qSkCedbNah9ei2W2765be8iMVxQUsvgT7zIAT2eIa9fs5+vtg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.8.5.tgz",
+      "integrity": "sha512-Ni8FuZ8yAF+sWZzojvtLE2b03cqjO5jNULcHFfM9ZZ0/JXrgom5pBREbtnAw7oxsxJqHw9Nz/XWORUEL3/IFow==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.9.6.tgz",
+      "integrity": "sha512-rFen0G7adh1YmgvrmE5IPIqbb+IgEzENUm+tzm6MLLDSlPRoZVhzU1WdML9PV2W5GOdRA9qBKURlbt1OsXOsPw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.9.5.tgz",
+      "integrity": "sha512-DYTWtWpfd5FOro3UnAfwvhD8jh59r2ig8bPtc9H8Ds7MscE/9NYruUQWFAOuraRl29jwcT2kyMFQ3MxeaVjUhg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -9609,6 +9712,45 @@
         "node": ">=4"
       }
     },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -9713,6 +9855,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10425,8 +10568,19 @@
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -11123,6 +11277,8 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
       "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -11844,6 +12000,8 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -12053,6 +12211,8 @@
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
       "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tr46": "^5.1.0",
         "webidl-conversions": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/typeorm": "^11.0.0",
-    "mongodb": "^6.16.0",
+    "pg": "^8.15.6",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,7 +3,19 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { CartsModule, OrdersModule, ProductsModule } from './modules';
+import {
+  AddressModule,
+  CartModule,
+  CategoryModule,
+  CustomerModule,
+  LineItemModule,
+  OrderModule,
+  ProductModule,
+  PromotionModule,
+  ShippingMethodModule,
+  UserModule,
+  VariantModule,
+} from './modules';
 import {
   Address,
   Cart,
@@ -11,10 +23,11 @@ import {
   Customer,
   LineItem,
   Order,
+  Variant,
   Product,
   Promotion,
   ShippingMethod,
-  Variant,
+  User,
 } from './entities';
 
 @Module({
@@ -28,9 +41,11 @@ import {
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: (config: ConfigService) => ({
-        type: 'mongodb',
+        type: 'postgres',
         host: config.get<string>('DB_HOST'),
         port: config.get<number>('DB_PORT'),
+        username: config.get<string>('DB_USERNAME'),
+        password: config.get<string>('DB_PASSWORD'),
         database: config.get<string>('DB_NAME'),
         entities: [
           Address,
@@ -39,24 +54,33 @@ import {
           Customer,
           LineItem,
           Order,
+          Variant,
           Product,
           Promotion,
           ShippingMethod,
-          Variant,
+          User,
         ],
         synchronize: true,
         logging: true,
       }),
     }),
-    CartsModule,
-    ProductsModule,
-    OrdersModule,
+    AddressModule,
+    CartModule,
+    CategoryModule,
+    CustomerModule,
+    LineItemModule,
+    OrderModule,
+    ProductModule,
+    PromotionModule,
+    ShippingMethodModule,
+    UserModule,
+    VariantModule,
   ],
   controllers: [AppController],
   providers: [AppService],
 })
 export class AppModule {
   constructor() {
-    Logger.log('MongoDB connection established');
+    Logger.log('PostgreSQL connection established');
   }
 }

--- a/src/entities/address.entity.ts
+++ b/src/entities/address.entity.ts
@@ -1,10 +1,10 @@
-import { Entity, ObjectIdColumn, Column } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
 import { IAddress } from '../interfaces';
 
 @Entity()
 export class Address implements IAddress {
-  @ObjectIdColumn()
-  _id: string;
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
 
   @Column()
   firstName: string;

--- a/src/entities/cart.entity.ts
+++ b/src/entities/cart.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, ObjectIdColumn, Column } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
 import { ICart } from '../interfaces';
 import { LineItem } from './line-item.entity';
 import { Customer } from './customer.entity';
@@ -8,8 +8,8 @@ import { ShippingMethod } from './shipping-method.entity';
 
 @Entity()
 export class Cart implements ICart {
-  @ObjectIdColumn()
-  _id: string;
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
 
   @Column()
   currencyCode: string;

--- a/src/entities/category.entity.ts
+++ b/src/entities/category.entity.ts
@@ -1,10 +1,10 @@
 import { ICategory } from '../interfaces';
-import { Entity, ObjectIdColumn, Column, BeforeUpdate } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, BeforeUpdate } from 'typeorm';
 
 @Entity()
 export class Category implements ICategory {
-  @ObjectIdColumn()
-  _id: string;
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
 
   @Column()
   name: string;

--- a/src/entities/customer.entity.ts
+++ b/src/entities/customer.entity.ts
@@ -1,11 +1,18 @@
-import { Entity, ObjectIdColumn, Column } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  OneToOne,
+  JoinColumn,
+} from 'typeorm';
 import { ICustomer } from '../interfaces';
 import { Address } from './address.entity';
+import { User } from './user.entity';
 
 @Entity()
 export class Customer implements ICustomer {
-  @ObjectIdColumn()
-  _id: string;
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
 
   @Column()
   firstName: string;
@@ -13,12 +20,10 @@ export class Customer implements ICustomer {
   @Column()
   lastName: string;
 
-  @Column()
-  email: string;
-
-  @Column()
-  phone: string;
-
   @Column(() => Address)
   addresses: Address[];
+
+  @OneToOne(() => User, (user) => user.customer, { cascade: true })
+  @JoinColumn()
+  user: User;
 }

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -8,3 +8,4 @@ export * from './product-variant.entity';
 export * from './product.entity';
 export * from './promotion.entity';
 export * from './shipping-method.entity';
+export * from './user.entity';

--- a/src/entities/line-item.entity.ts
+++ b/src/entities/line-item.entity.ts
@@ -1,10 +1,10 @@
-import { Entity, ObjectIdColumn, Column } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
 import { ILineItem } from '../interfaces';
 
 @Entity()
 export class LineItem implements ILineItem {
-  @ObjectIdColumn()
-  _id: string;
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
 
   @Column()
   productId: string;

--- a/src/entities/order.entity.ts
+++ b/src/entities/order.entity.ts
@@ -1,6 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
+  PrimaryGeneratedColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -11,8 +11,8 @@ import { Address, Customer, LineItem } from '../entities';
 
 @Entity()
 export class Order implements IOrder {
-  @ObjectIdColumn()
-  _id: ObjectId | string;
+  @PrimaryGeneratedColumn('uuid')
+  id: ObjectId | string;
 
   @Column(() => Customer)
   customer: Customer;

--- a/src/entities/product-variant.entity.ts
+++ b/src/entities/product-variant.entity.ts
@@ -1,10 +1,10 @@
-import { Entity, ObjectIdColumn, Column, BeforeUpdate } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, BeforeUpdate } from 'typeorm';
 import { IVariant } from '../interfaces';
 
 @Entity()
 export class Variant implements IVariant {
-  @ObjectIdColumn()
-  _id: string;
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
 
   @Column()
   title: string;

--- a/src/entities/product.entity.ts
+++ b/src/entities/product.entity.ts
@@ -1,10 +1,10 @@
-import { Entity, ObjectIdColumn, Column, BeforeUpdate } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, BeforeUpdate } from 'typeorm';
 import { Category, Variant } from './';
 
 @Entity()
 export class Product {
-  @ObjectIdColumn()
-  _id: string;
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
 
   @Column()
   title: string;

--- a/src/entities/product.entity.ts
+++ b/src/entities/product.entity.ts
@@ -1,4 +1,12 @@
-import { Entity, PrimaryGeneratedColumn, Column, BeforeUpdate } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  BeforeUpdate,
+  OneToMany,
+  ManyToMany,
+  JoinTable,
+} from 'typeorm';
 import { Category, Variant } from './';
 
 @Entity()
@@ -21,16 +29,17 @@ export class Product {
   @Column()
   thumbnail: string;
 
-  @Column()
+  @Column('simple-array')
   images: string[];
 
-  @Column(() => Variant)
+  @OneToMany(() => Variant, (variant) => variant)
   variants: Variant[];
 
-  @Column(() => Category)
+  @ManyToMany(() => Category)
+  @JoinTable()
   categories: Category[];
 
-  @Column()
+  @Column('simple-array')
   tags: string[];
 
   @Column()

--- a/src/entities/promotion.entity.ts
+++ b/src/entities/promotion.entity.ts
@@ -1,6 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
+  PrimaryGeneratedColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -11,8 +11,8 @@ import { IPromotion } from '../interfaces';
 
 @Entity()
 export class Promotion implements IPromotion {
-  @ObjectIdColumn()
-  _id: ObjectId | string;
+  @PrimaryGeneratedColumn('uuid')
+  id: ObjectId | string;
 
   @Column({ unique: true })
   code: string;

--- a/src/entities/shipping-method.entity.ts
+++ b/src/entities/shipping-method.entity.ts
@@ -1,6 +1,6 @@
 import {
   Entity,
-  ObjectIdColumn,
+  PrimaryGeneratedColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -10,8 +10,8 @@ import { ObjectId } from 'mongodb';
 
 @Entity()
 export class ShippingMethod implements IShippingMethod {
-  @ObjectIdColumn()
-  _id: ObjectId | string;
+  @PrimaryGeneratedColumn('uuid')
+  id: ObjectId | string;
 
   @Column()
   name: string;

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -1,0 +1,21 @@
+import { Entity, PrimaryGeneratedColumn, Column, OneToOne } from 'typeorm';
+import { Customer } from './customer.entity';
+import { IUser } from '../interfaces/user.interface';
+
+@Entity()
+export class User implements IUser {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ unique: true })
+  email: string;
+
+  @Column()
+  phone: string;
+
+  @Column({ unique: true })
+  password: string;
+
+  @OneToOne(() => Customer, (customer) => customer.user)
+  customer: Customer;
+}

--- a/src/interfaces/address.interface.ts
+++ b/src/interfaces/address.interface.ts
@@ -1,7 +1,7 @@
 import { ObjectId } from 'mongodb';
 
 export interface IAddress {
-  _id?: ObjectId | string;
+  id?: ObjectId | string;
   firstName: string;
   lastName: string;
   addressLine1: string;

--- a/src/interfaces/cart.interface.ts
+++ b/src/interfaces/cart.interface.ts
@@ -6,7 +6,7 @@ import { IShippingMethod } from './shipping-method.interface';
 import { ICustomer } from './customer.interface';
 
 export interface ICart {
-  _id?: ObjectId | string;
+  id?: ObjectId | string;
   currencyCode: string;
   items: ILineItem[];
   customer: ICustomer;

--- a/src/interfaces/category.interface.ts
+++ b/src/interfaces/category.interface.ts
@@ -1,7 +1,7 @@
 import { ObjectId } from 'mongodb';
 
 export interface ICategory {
-  _id?: ObjectId | string;
+  id?: ObjectId | string;
   name: string;
   description: string;
   handle: string;

--- a/src/interfaces/customer.interface.ts
+++ b/src/interfaces/customer.interface.ts
@@ -1,11 +1,11 @@
 import { ObjectId } from 'mongodb';
 import { IAddress } from './address.interface';
+import { IUser } from './user.interface';
 
 export interface ICustomer {
-  _id?: ObjectId | string;
+  id?: ObjectId | string;
   firstName: string;
   lastName: string;
-  email: string;
-  phone: string;
   addresses: IAddress[];
+  user: IUser;
 }

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -8,3 +8,4 @@ export * from './product.interface';
 export * from './promotion.interface';
 export * from './shipping-method.interface';
 export * from './variant.interface';
+export * from './user.interface';

--- a/src/interfaces/line-item.interface.ts
+++ b/src/interfaces/line-item.interface.ts
@@ -1,7 +1,7 @@
 import { ObjectId } from 'mongodb';
 
 export interface ILineItem {
-  _id?: ObjectId | string;
+  id?: ObjectId | string;
   productId: ObjectId | string;
   variantId?: ObjectId | string;
   quantity: number;

--- a/src/interfaces/order.interface.ts
+++ b/src/interfaces/order.interface.ts
@@ -2,7 +2,7 @@ import { ObjectId } from 'mongodb';
 import { IAddress, ICustomer, ILineItem } from './';
 
 export interface IOrder {
-  _id?: ObjectId | string;
+  id?: ObjectId | string;
   customer: ICustomer;
   status: string;
   paymentStatus: string;

--- a/src/interfaces/product.interface.ts
+++ b/src/interfaces/product.interface.ts
@@ -3,7 +3,7 @@ import { IVariant } from './variant.interface';
 import { ICategory } from './category.interface';
 
 export interface IProduct {
-  _id?: ObjectId | string;
+  id?: ObjectId | string;
   title: string;
   handle: string;
   description: string;

--- a/src/interfaces/promotion.interface.ts
+++ b/src/interfaces/promotion.interface.ts
@@ -1,7 +1,7 @@
 import { ObjectId } from 'mongodb';
 
 export interface IPromotion {
-  _id?: ObjectId | string;
+  id?: ObjectId | string;
   code: string;
   discount: number;
 }

--- a/src/interfaces/shipping-method.interface.ts
+++ b/src/interfaces/shipping-method.interface.ts
@@ -1,7 +1,7 @@
 import { ObjectId } from 'mongodb';
 
 export interface IShippingMethod {
-  _id?: ObjectId | string;
+  id?: ObjectId | string;
   name: string;
   amount: number;
   createdAt?: Date;

--- a/src/interfaces/user.interface.ts
+++ b/src/interfaces/user.interface.ts
@@ -1,0 +1,8 @@
+import { ObjectId } from 'mongodb';
+
+export interface IUser {
+  id?: ObjectId | string;
+  email: string;
+  phone: string;
+  password: string;
+}

--- a/src/interfaces/variant.interface.ts
+++ b/src/interfaces/variant.interface.ts
@@ -1,7 +1,7 @@
 import { ObjectId } from 'mongodb';
 
 export interface IVariant {
-  _id?: ObjectId | string;
+  id?: ObjectId | string;
   title: string;
   sku: string;
   barcode: string;

--- a/src/modules/address.module.ts
+++ b/src/modules/address.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Address } from '../entities/address.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Address])],
+  exports: [TypeOrmModule],
+})
+export class AddressModule {}

--- a/src/modules/cart.module.ts
+++ b/src/modules/cart.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Cart } from '../entities/cart.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Cart])],
+  exports: [TypeOrmModule],
+})
+export class CartModule {}

--- a/src/modules/category.module.ts
+++ b/src/modules/category.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Category } from '../entities/category.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Category])],
+  exports: [TypeOrmModule],
+})
+export class CategoryModule {}

--- a/src/modules/customer.module.ts
+++ b/src/modules/customer.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Customer } from '../entities/customer.entity';
+import { CustomerRepository } from 'src/repositories';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Customer])],
+  providers: [CustomerRepository],
+  exports: [CustomerRepository],
+})
+export class CustomerModule {}

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,3 +1,11 @@
-export { CartsModule } from './carts.module';
-export { OrdersModule } from './orders.module';
-export { ProductsModule } from './products.module';
+export { AddressModule } from './address.module';
+export { CartModule } from './cart.module';
+export { CategoryModule } from './category.module';
+export { CustomerModule } from './customer.module';
+export { LineItemModule } from './line-item.module';
+export { OrderModule } from './order.module';
+export { ProductModule } from './product.module';
+export { PromotionModule } from './promotion.module';
+export { ShippingMethodModule } from './shipping-method.module';
+export { UserModule } from './user.module';
+export { VariantModule } from './variant.module';

--- a/src/modules/line-item.module.ts
+++ b/src/modules/line-item.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { LineItem } from '../entities/line-item.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([LineItem])],
+  exports: [TypeOrmModule],
+})
+export class LineItemModule {}

--- a/src/modules/order.module.ts
+++ b/src/modules/order.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Order } from '../entities/order.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Order])],
+  exports: [TypeOrmModule],
+})
+export class OrderModule {}

--- a/src/modules/product.module.ts
+++ b/src/modules/product.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Product } from '../entities/product.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Product])],
+  exports: [TypeOrmModule],
+})
+export class ProductModule {}

--- a/src/modules/promotion.module.ts
+++ b/src/modules/promotion.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Promotion } from '../entities/promotion.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Promotion])],
+  exports: [TypeOrmModule],
+})
+export class PromotionModule {}

--- a/src/modules/shipping-method.module.ts
+++ b/src/modules/shipping-method.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ShippingMethod } from '../entities/shipping-method.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ShippingMethod])],
+  exports: [TypeOrmModule],
+})
+export class ShippingMethodModule {}

--- a/src/modules/user.module.ts
+++ b/src/modules/user.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from '../entities/user.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User])],
+  exports: [TypeOrmModule],
+})
+export class UserModule {}

--- a/src/modules/variant.module.ts
+++ b/src/modules/variant.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Variant } from '../entities/product-variant.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Variant])],
+  exports: [TypeOrmModule],
+})
+export class VariantModule {}

--- a/src/repositories/address.repository.ts
+++ b/src/repositories/address.repository.ts
@@ -1,0 +1,6 @@
+import { Repository } from 'typeorm';
+import { Address } from '../entities/address.entity';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AddressRepository extends Repository<Address> {}

--- a/src/repositories/cart.repository.ts
+++ b/src/repositories/cart.repository.ts
@@ -1,0 +1,6 @@
+import { Repository } from 'typeorm';
+import { Cart } from '../entities/cart.entity';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class CartRepository extends Repository<Cart> {}

--- a/src/repositories/category.repository.ts
+++ b/src/repositories/category.repository.ts
@@ -1,0 +1,6 @@
+import { Repository } from 'typeorm';
+import { Category } from '../entities/category.entity';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class CategoryRepository extends Repository<Category> {}

--- a/src/repositories/customer.repository.ts
+++ b/src/repositories/customer.repository.ts
@@ -1,0 +1,61 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Customer } from '../entities/customer.entity';
+
+@Injectable()
+export class CustomerRepository {
+  constructor(
+    @InjectRepository(Customer)
+    private readonly repository: Repository<Customer>,
+  ) {}
+
+  /**
+   * Retrieves all customers from the database.
+   * @returns {Promise<Customer[]>} A promise that resolves to an array of customers.
+   */
+  findAll = async (): Promise<Customer[]> => {
+    return this.repository.find();
+  };
+
+  /**
+   * Finds a customer by the associated user ID and includes the user entity.
+   * @param {string} userId - The ID of the user associated with the customer.
+   * @returns {Promise<Customer | null>} A promise that resolves to the customer or null if not found.
+   */
+  find = async (userId: string): Promise<Customer | null> => {
+    return this.repository.findOne({
+      where: { user: { id: userId } },
+      relations: ['user'],
+    });
+  };
+
+  /**
+   * Creates a new customer in the database.
+   * @param {Partial<Customer>} customer - The customer data to create.
+   * @returns {Promise<Customer>} A promise that resolves to the created customer.
+   */
+  create = async (customer: Partial<Customer>): Promise<Customer> => {
+    const newCustomer = this.repository.create(customer);
+    return this.repository.save(newCustomer);
+  };
+
+  /**
+   * Updates an existing customer in the database.
+   * @param {string} id - The ID of the customer to update.
+   * @param {Partial<Customer>} customer - The updated customer data.
+   * @returns {Promise<void>} A promise that resolves when the update is complete.
+   */
+  update = async (id: string, customer: Partial<Customer>): Promise<void> => {
+    await this.repository.update(id, customer);
+  };
+
+  /**
+   * Deletes a customer from the database.
+   * @param {string} id - The ID of the customer to delete.
+   * @returns {Promise<void>} A promise that resolves when the customer is deleted.
+   */
+  delete = async (id: string): Promise<void> => {
+    await this.repository.delete(id);
+  };
+}

--- a/src/repositories/index.ts
+++ b/src/repositories/index.ts
@@ -1,0 +1,10 @@
+export { CustomerRepository } from './customer.repository';
+export { AddressRepository } from './address.repository';
+export { CartRepository } from './cart.repository';
+export { CategoryRepository } from './category.repository';
+export { LineItemRepository } from './line-item.repository';
+export { OrderRepository } from './order.repository';
+export { ProductRepository } from './product.repository';
+export { PromotionRepository } from './promotion.repository';
+export { ShippingMethodRepository } from './shipping-method.repository';
+export { VariantRepository } from './variant.repository';

--- a/src/repositories/line-item.repository.ts
+++ b/src/repositories/line-item.repository.ts
@@ -1,0 +1,6 @@
+import { Repository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { LineItem } from '../entities/line-item.entity';
+
+@Injectable()
+export class LineItemRepository extends Repository<LineItem> {}

--- a/src/repositories/order.repository.ts
+++ b/src/repositories/order.repository.ts
@@ -1,0 +1,6 @@
+import { Repository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { Order } from '../entities/order.entity';
+
+@Injectable()
+export class OrderRepository extends Repository<Order> {}

--- a/src/repositories/product.repository.ts
+++ b/src/repositories/product.repository.ts
@@ -1,0 +1,6 @@
+import { Repository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { Product } from '../entities/product.entity';
+
+@Injectable()
+export class ProductRepository extends Repository<Product> {}

--- a/src/repositories/promotion.repository.ts
+++ b/src/repositories/promotion.repository.ts
@@ -1,0 +1,6 @@
+import { Repository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { Promotion } from '../entities/promotion.entity';
+
+@Injectable()
+export class PromotionRepository extends Repository<Promotion> {}

--- a/src/repositories/shipping-method.repository.ts
+++ b/src/repositories/shipping-method.repository.ts
@@ -1,0 +1,6 @@
+import { Repository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { ShippingMethod } from '../entities/shipping-method.entity';
+
+@Injectable()
+export class ShippingMethodRepository extends Repository<ShippingMethod> {}

--- a/src/repositories/variant.repository.ts
+++ b/src/repositories/variant.repository.ts
@@ -1,0 +1,6 @@
+import { Repository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { Variant } from '../entities/product-variant.entity';
+
+@Injectable()
+export class VariantRepository extends Repository<Variant> {}


### PR DESCRIPTION
Refactor the codebase to replace ObjectId with UUIDs for entity identifiers and transition from MongoDB to PostgreSQL. Introduce new modules and repository classes for various entities, ensuring proper relationships and imports. Update configuration for the new database setup.